### PR TITLE
BUGFIX: QA-5047 - Before manipulating with GitHub repository test whethe...

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbRepository.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbRepository.java
@@ -114,6 +114,7 @@ public class GhprbRepository {
 
 	public void createCommitStatus(String sha1, GHCommitState state, String url, String message, int id) {
 		logger.log(Level.INFO, "Setting status of {0} to {1} with url {2} and message: {3}", new Object[]{sha1, state, url, message});
+		if(!checkState()) return;
 		try {
 			repo.createCommitStatus(sha1, state, url, message);
 		} catch (IOException ex) {
@@ -133,6 +134,7 @@ public class GhprbRepository {
 	public void addComment(int id, String comment) {
 		if (comment.isEmpty())
 			return;
+		if(!checkState()) return;
 		try {
 			repo.getPullRequest(id).comment(comment);
 		} catch (IOException ex) {
@@ -141,6 +143,7 @@ public class GhprbRepository {
 	}
 
 	public void closePullRequest(int id) {
+		if(!checkState()) return;
 		try {
 			repo.getPullRequest(id).close();
 		} catch (IOException ex) {


### PR DESCRIPTION
...r the object is initialised

The object for manipulation with the GitHub repository is intialised
by default when the Trigger is created or the Jenkins is started. But
when in time of trigger creation the Jenkins does not have permission
to pull the repository, the object is not created and the job does
not work properly and fails every time when accessing the repo even
after the permission has been fixed.